### PR TITLE
✨feat(analysis): Add complexity metrics calculation for PLSQL_CodeObject nodes in dependency graph

### DIFF
--- a/packages/dependency_analyzer/src/dependency_analyzer/analysis/analyzer.py
+++ b/packages/dependency_analyzer/src/dependency_analyzer/analysis/analyzer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import networkx as nx
 import loguru as lg # type: ignore
 from typing import List, Dict, Set, Optional, Generator, Tuple
+import re
 
 # Assuming plsql_analyzer is a package accessible in the Python path.
 # This import might be needed if we directly access PLSQL_CodeObject attributes like type.
@@ -415,6 +416,56 @@ def get_connected_components(
     except Exception as e:
         logger.error(f"Error finding {component_type} connected components: {e}", exc_info=True)
         return []
+
+
+def calculate_node_complexity_metrics(graph: nx.DiGraph, logger: lg.Logger) -> None:
+    """
+    Calculates and stores complexity metrics for each PLSQL_CodeObject node in the graph.
+    Metrics:
+        - loc: Lines of Code (LOC) based on clean_code
+        - num_params: Number of parameters (parsed_parameters)
+        - num_calls_made: Number of outgoing calls (unique callees in extracted_calls)
+        - acc: Approximate Cyclomatic Complexity (heuristic based on control flow keywords)
+    Stores metrics as node attributes: 'loc', 'num_params', 'num_calls_made', 'acc'.
+    """
+    if not graph:
+        logger.warning("Graph is empty or None. Cannot calculate complexity metrics.")
+        return
+
+    # Decision-point keywords for ACC (case-insensitive, word boundaries)
+    keywords = [
+        r'\bif\b', r'\belsif\b', r'\bcase\b', r'\bwhen\b', r'\bloop\b',
+        r'\bfor\b', r'\bwhile\b', r'\bexception\b', r'\bthen\b'
+    ]
+    acc_pattern = re.compile('|'.join(keywords), re.IGNORECASE)
+
+    for node_id, node_data in graph.nodes(data=True):
+        obj = node_data.get('object')
+        if obj is None:
+            logger.warning(f"Node '{node_id}' missing 'object' attribute. Skipping complexity metrics.")
+            continue
+        # LOC
+        loc = len(obj.clean_code.splitlines()) if obj.clean_code else 0
+        # Number of parameters
+        num_params = len(obj.parsed_parameters) if hasattr(obj, 'parsed_parameters') and obj.parsed_parameters else 0
+        # Number of outgoing calls (unique callees)
+        if hasattr(obj, 'extracted_calls') and obj.extracted_calls:
+            unique_callees = set(getattr(call, 'call_name', None) for call in obj.extracted_calls if hasattr(call, 'call_name'))
+            num_calls_made = len(unique_callees)
+        else:
+            num_calls_made = 0
+        # Approximate Cyclomatic Complexity (ACC)
+        if obj.clean_code:
+            acc_count = len(acc_pattern.findall(obj.clean_code))
+            acc = acc_count + 1
+        else:
+            acc = 1
+        # Store metrics as node attributes
+        graph.nodes[node_id]['loc'] = loc
+        graph.nodes[node_id]['num_params'] = num_params
+        graph.nodes[node_id]['num_calls_made'] = num_calls_made
+        graph.nodes[node_id]['acc'] = acc
+        logger.debug(f"Node '{node_id}': LOC={loc}, Params={num_params}, Calls={num_calls_made}, ACC={acc}")
 
 # --- Example Usage (Illustrative) ---
 if __name__ == '__main__':

--- a/packages/dependency_analyzer/tests/analysis/test_analyzer.py
+++ b/packages/dependency_analyzer/tests/analysis/test_analyzer.py
@@ -631,3 +631,103 @@ def test_calculate_node_complexity_metrics_complex(complex_graph, da_test_logger
         assert 'acc' in node_data
         # ACC should be >= 1
         assert node_data['acc'] >= 1
+
+def test_calculate_node_complexity_metrics_specific_values(da_test_logger: lg.Logger):
+    graph = nx.DiGraph()
+    mock_obj_code = (
+        "IF condition1 THEN\n"
+        "  call_a();\n"
+        "ELSIF condition2 THEN\n"
+        "  call_b();\n"
+        "  call_a(); -- duplicate call\n"
+        "ELSE\n"
+        "  FOR i IN 1..10 LOOP\n"
+        "    call_c();\n"
+        "  END LOOP;\n"
+        "END IF;"
+    )
+    mock_obj_params = [{'name': 'p1', 'type': 'VARCHAR2'}, {'name': 'p2', 'type': 'NUMBER'}]
+    mock_obj_calls = [
+        CallDetailsTuple(call_name='call_a', line_no=2, start_idx=0, end_idx=0, positional_params=[], named_params={}),
+        CallDetailsTuple(call_name='call_b', line_no=4, start_idx=0, end_idx=0, positional_params=[], named_params={}),
+        CallDetailsTuple(call_name='call_a', line_no=5, start_idx=0, end_idx=0, positional_params=[], named_params={}),
+        CallDetailsTuple(call_name='call_c', line_no=8, start_idx=0, end_idx=0, positional_params=[], named_params={}),
+    ]
+    
+    mock_node_obj = MockPLSQLCodeObject(
+        name="TestProc",
+        clean_code=mock_obj_code,
+        parsed_parameters=mock_obj_params,
+        extracted_calls=mock_obj_calls
+    )
+    graph.add_node("TestProcNode", object=mock_node_obj)
+
+    calculate_node_complexity_metrics(graph, da_test_logger)
+    
+    node_data = graph.nodes["TestProcNode"]
+    assert node_data['loc'] == 10
+    assert node_data['num_params'] == 2
+    assert node_data['num_calls_made'] == 3 # unique: call_a, call_b, call_c
+    
+    # This assertion depends on whether 'THEN' is counted in ACC
+    # If THEN is counted: IF, THEN, ELSIF, THEN, FOR, LOOP = 6 keywords. ACC = 6 + 1 = 7
+    # If THEN is NOT counted: IF, ELSIF, FOR, LOOP = 4 keywords. ACC = 4 + 1 = 5
+    expected_acc = 7 # Assuming 'THEN' is counted as per current implementation
+    assert node_data['acc'] == expected_acc, f"ACC mismatch: got {node_data['acc']}, want {expected_acc}"
+
+def test_analyze_metrics_infers_format_and_saves(tmp_path, da_test_logger):
+    import shutil
+    from dependency_analyzer.analysis.analyzer import calculate_node_complexity_metrics
+    from dependency_analyzer.cli import analyze_metrics
+    import networkx as nx
+    import types
+    # Create a test graph and save as .graphml
+    G = nx.DiGraph()
+    G.add_node("A")
+    G.add_node("B")
+    G.add_edge("A", "B")
+    graphml_path = tmp_path / "testgraph.graphml"
+    nx.write_graphml_lxml(G=G, path=graphml_path)
+
+    # Patch analyzer.calculate_node_complexity_metrics to check call
+    called = {}
+    def fake_calc(graph, logger):
+        called['called'] = True
+        assert isinstance(graph, nx.DiGraph)
+    orig_calc = calculate_node_complexity_metrics
+    import dependency_analyzer.analysis.analyzer as analyzer_mod
+    analyzer_mod.calculate_node_complexity_metrics = fake_calc
+
+    # Patch GraphStorage to check format used for load/save
+    from dependency_analyzer.persistence.graph_storage import GraphStorage
+    orig_load_graph = GraphStorage.load_graph
+    orig_save_structure_only = GraphStorage.save_structure_only
+    used_formats = {}
+    def fake_load(self, path, format):
+        used_formats['load'] = format
+        # Return a DiGraph with the expected structure for the test
+        G_loaded = nx.DiGraph()
+        G_loaded.add_node("A", object=None)
+        G_loaded.add_node("B", object=None)
+        G_loaded.add_edge("A", "B")
+        return G_loaded
+    def fake_save(self, graph, path, format):
+        used_formats['save'] = format
+        return True
+    GraphStorage.load_graph = fake_load
+    GraphStorage.save_structure_only = fake_save
+
+    # Call the CLI command (simulate user passing only the file, not format)
+    analyze_metrics(
+        graph_path=graphml_path,
+        graph_format="gpickle",  # default, should be overridden by .graphml
+        verbose_level=0
+    )
+    assert used_formats['load'] == 'graphml'
+    assert used_formats['save'] == 'graphml'
+    assert called['called']
+
+    # Restore
+    analyzer_mod.calculate_node_complexity_metrics = orig_calc
+    GraphStorage.load_graph = orig_load_graph
+    GraphStorage.save_structure_only = orig_save_structure_only


### PR DESCRIPTION
Closes #1 

- Introduce `calculate_node_complexity_metrics` in `analyzer.py` to compute LOC, number of parameters, outgoing calls, and approximate cyclomatic complexity (ACC) for each PLSQL_CodeObject node.
- Add `--calculate-complexity` flag to `full_build` CLI command to optionally compute and store these metrics.
- Add new CLI command `analyze_metrics` to compute and update metrics for an existing graph file.
- Store metrics as node attributes: `loc`, `num_params`, `num_calls_made`, `acc`.
- Add unit tests for metric calculation logic.