### PR TITLE
✨feat(analysis,cli): Add reachability analysis commands and implement descendant/ancestor retrieval functions

### DIFF
--- a/packages/dependency_analyzer/src/dependency_analyzer/analysis/analyzer.py
+++ b/packages/dependency_analyzer/src/dependency_analyzer/analysis/analyzer.py
@@ -475,6 +475,47 @@ def calculate_node_complexity_metrics(graph: nx.DiGraph, logger: lg.Logger) -> N
         graph.nodes[node_id]['acc'] = acc
         logger.debug(f"Node '{node_id}': LOC={loc}, Params={num_params}, Calls={num_calls_made}, ACC={acc}")
 
+def get_descendants(graph: nx.DiGraph, source_node: str, depth_limit: Optional[int] = None) -> Set[str]:
+    """
+    Returns the set of all descendant nodes (reachable from source_node) in the graph.
+    If depth_limit is None, returns all descendants. Otherwise, limits traversal depth.
+
+    Args:
+        graph: The NetworkX DiGraph.
+        source_node: The node from which to find descendants.
+        depth_limit: Optional maximum depth for traversal.
+
+    Returns:
+        Set of descendant node IDs (excluding source_node itself).
+    """
+    if source_node not in graph:
+        return set()
+    if depth_limit is None:
+        return nx.descendants(graph, source_node)
+    # BFS tree includes the source node, so remove it
+    return set(nx.bfs_tree(graph, source_node, depth_limit=depth_limit).nodes()) - {source_node}
+
+
+def get_ancestors(graph: nx.DiGraph, target_node: str, depth_limit: Optional[int] = None) -> Set[str]:
+    """
+    Returns the set of all ancestor nodes (can reach target_node) in the graph.
+    If depth_limit is None, returns all ancestors. Otherwise, limits traversal depth.
+
+    Args:
+        graph: The NetworkX DiGraph.
+        target_node: The node for which to find ancestors.
+        depth_limit: Optional maximum depth for traversal.
+
+    Returns:
+        Set of ancestor node IDs (excluding target_node itself).
+    """
+    if target_node not in graph:
+        return set()
+    if depth_limit is None:
+        return nx.ancestors(graph, target_node)
+    # Use reversed graph for upstream traversal
+    return set(nx.bfs_tree(graph.reverse(copy=False), target_node, depth_limit=depth_limit).nodes()) - {target_node}
+
 # --- Example Usage (Illustrative) ---
 if __name__ == '__main__':
     # Basic Logger Setup for Example

--- a/packages/dependency_analyzer/src/dependency_analyzer/cli.py
+++ b/packages/dependency_analyzer/src/dependency_analyzer/cli.py
@@ -370,5 +370,6 @@ def analyze_reachability(
         print(result_message)
     if upstream:
         ancestors = analyzer.get_ancestors(graph, node_id, depth_limit=depth)
-        local_logger.info(f"Ancestors (upstream) of '{node_id}' (depth_limit={depth}): {sorted(ancestors) if ancestors else 'None'}")
-        print(f"Ancestors (upstream) of '{node_id}' (depth_limit={depth}): {sorted(ancestors) if ancestors else 'None'}")
+        result_message = f"Ancestors (upstream) of '{node_id}' (depth_limit={depth}): {sorted(ancestors) if ancestors else 'None'}"
+        local_logger.info(result_message)
+        print(result_message)

--- a/packages/dependency_analyzer/src/dependency_analyzer/cli.py
+++ b/packages/dependency_analyzer/src/dependency_analyzer/cli.py
@@ -365,8 +365,9 @@ def analyze_reachability(
 
     if downstream:
         descendants = analyzer.get_descendants(graph, node_id, depth_limit=depth)
-        local_logger.info(f"Descendants (downstream) of '{node_id}' (depth_limit={depth}): {sorted(descendants) if descendants else 'None'}")
-        print(f"Descendants (downstream) of '{node_id}' (depth_limit={depth}): {sorted(descendants) if descendants else 'None'}")
+        result_message = f"Descendants (downstream) of '{node_id}' (depth_limit={depth}): {sorted(descendants) if descendants else 'None'}"
+        local_logger.info(result_message)
+        print(result_message)
     if upstream:
         ancestors = analyzer.get_ancestors(graph, node_id, depth_limit=depth)
         local_logger.info(f"Ancestors (upstream) of '{node_id}' (depth_limit={depth}): {sorted(ancestors) if ancestors else 'None'}")

--- a/packages/dependency_analyzer/src/dependency_analyzer/cli.py
+++ b/packages/dependency_analyzer/src/dependency_analyzer/cli.py
@@ -322,3 +322,52 @@ def analyze_metrics(
         local_logger.info(f"Metrics calculated and graph updated at '{graph_path}' (format: '{actual_load_format}').")
     else:
         local_logger.error(f"Failed to save updated graph with metrics to '{graph_path}' (format: '{actual_load_format}').")
+
+@app.command
+def analyze_reachability(
+    graph_path: Path = Parameter(..., help="Path to the dependency graph file (full or subgraph)."),
+    node_id: str = Parameter(..., help="Node ID to analyze reachability for."),
+    downstream: bool = Parameter(True, help="Show descendants (downstream reachability)."),
+    upstream: bool = Parameter(True, help="Show ancestors (upstream reachability)."),
+    depth: Optional[int] = Parameter(None, help="Optional depth limit for traversal."),
+    graph_format: str = Parameter(da_config.DEFAULT_GRAPH_FORMAT, help=f"Format of the graph file. Options: {da_config.VALID_GRAPH_FORMATS}"),
+    verbose_level: int = Parameter(da_config.LOG_VERBOSE_LEVEL, help="Logging verbosity (0-3)."),
+):
+    """
+    Analyze reachability for a given node in the dependency graph.
+    Reports all descendants (downstream) and/or ancestors (upstream) of the node, with optional depth limit.
+    """
+    local_logger = _setup(verbose_level)
+    local_logger.info(f"Analyzing reachability for node '{node_id}' in '{graph_path}' (downstream={downstream}, upstream={upstream}, depth={depth})")
+
+    if not graph_path.exists():
+        local_logger.critical(f"Graph file not found: {graph_path}")
+        return
+
+    graph_storage = GraphStorage(local_logger)
+    actual_load_format = graph_format
+    if graph_format == da_config.DEFAULT_GRAPH_FORMAT:
+        inferred_format_from_ext = graph_path.suffix.lstrip('.').lower()
+        if inferred_format_from_ext and inferred_format_from_ext in da_config.VALID_GRAPH_FORMATS:
+            actual_load_format = inferred_format_from_ext
+            local_logger.info(f"Using inferred format '{actual_load_format}' for loading '{graph_path}'.")
+        else:
+            local_logger.info(f"Using default/specified format '{actual_load_format}' for loading '{graph_path}'.")
+
+    graph = graph_storage.load_graph(graph_path, format=actual_load_format)
+    if not graph:
+        local_logger.error(f"Failed to load graph from '{graph_path}' using format '{actual_load_format}'.")
+        return
+
+    if node_id not in graph:
+        local_logger.error(f"Node '{node_id}' not found in the loaded graph.")
+        return
+
+    if downstream:
+        descendants = analyzer.get_descendants(graph, node_id, depth_limit=depth)
+        local_logger.info(f"Descendants (downstream) of '{node_id}' (depth_limit={depth}): {sorted(descendants) if descendants else 'None'}")
+        print(f"Descendants (downstream) of '{node_id}' (depth_limit={depth}): {sorted(descendants) if descendants else 'None'}")
+    if upstream:
+        ancestors = analyzer.get_ancestors(graph, node_id, depth_limit=depth)
+        local_logger.info(f"Ancestors (upstream) of '{node_id}' (depth_limit={depth}): {sorted(ancestors) if ancestors else 'None'}")
+        print(f"Ancestors (upstream) of '{node_id}' (depth_limit={depth}): {sorted(ancestors) if ancestors else 'None'}")


### PR DESCRIPTION

- Add CLI command `analyze_reachability` to expose ancestor/descendant reachability analysis with optional depth limit.
- Prints and logs results for both downstream (descendants) and upstream (ancestors).
- Updates changelog with new CLI feature.