### PR TITLE
✨feat(classification): Add node classification functionality to categorize architectural roles

### DIFF
--- a/packages/dependency_analyzer/tests/analysis/test_analyzer.py
+++ b/packages/dependency_analyzer/tests/analysis/test_analyzer.py
@@ -663,20 +663,7 @@ def test_classify_nodes_basic(complex_graph, da_test_logger: lg.Logger):
     found_any = any('hub' in r or 'utility' in r or 'orphan_component_member' in r for r in roles.values())
     assert found_any
 
-def test_classify_nodes_basic(complex_graph, da_test_logger: lg.Logger):
-    from dependency_analyzer.analysis.analyzer import classify_nodes
-    classify_nodes(complex_graph, da_test_logger, complexity_metrics_available=False)
-    # Check that node_role is assigned and at least one hub, utility, orphan, entry, terminal exists
-    roles = {n: complex_graph.nodes[n].get('node_role', []) for n in complex_graph.nodes()}
-    # There should be entry points
-    entry_points = [n for n, r in roles.items() if 'entry_point' in r]
-    assert set(entry_points) == {'EntryA', 'EntryB', 'Iso'}
-    # There should be terminal nodes
-    terminal_nodes = [n for n, r in roles.items() if 'terminal_node' in r]
-    assert 'T1' in terminal_nodes and 'Iso' in terminal_nodes
-    # There should be at least one hub or utility or orphan
-    found_any = any('hub' in r or 'utility' in r or 'orphan_component_member' in r for r in roles.values())
-    assert found_any
+# Removed duplicate definition of test_classify_nodes_basic
 
 
 # 9. calculate_node_complexity_metrics

--- a/packages/dependency_analyzer/tests/analysis/test_analyzer.py
+++ b/packages/dependency_analyzer/tests/analysis/test_analyzer.py
@@ -648,6 +648,37 @@ def test_get_connected_components_complex_weakly(complex_graph, da_test_logger: 
     assert found_wcc_sets == expected_wcc_sets
 
 
+def test_classify_nodes_basic(complex_graph, da_test_logger: lg.Logger):
+    from dependency_analyzer.analysis.analyzer import classify_nodes
+    classify_nodes(complex_graph, da_test_logger, complexity_metrics_available=False)
+    # Check that node_role is assigned and at least one hub, utility, orphan, entry, terminal exists
+    roles = {n: complex_graph.nodes[n].get('node_role', []) for n in complex_graph.nodes()}
+    # There should be entry points
+    entry_points = [n for n, r in roles.items() if 'entry_point' in r]
+    assert set(entry_points) == {'EntryA', 'EntryB', 'Iso'}
+    # There should be terminal nodes
+    terminal_nodes = [n for n, r in roles.items() if 'terminal_node' in r]
+    assert 'T1' in terminal_nodes and 'Iso' in terminal_nodes
+    # There should be at least one hub or utility or orphan
+    found_any = any('hub' in r or 'utility' in r or 'orphan_component_member' in r for r in roles.values())
+    assert found_any
+
+def test_classify_nodes_basic(complex_graph, da_test_logger: lg.Logger):
+    from dependency_analyzer.analysis.analyzer import classify_nodes
+    classify_nodes(complex_graph, da_test_logger, complexity_metrics_available=False)
+    # Check that node_role is assigned and at least one hub, utility, orphan, entry, terminal exists
+    roles = {n: complex_graph.nodes[n].get('node_role', []) for n in complex_graph.nodes()}
+    # There should be entry points
+    entry_points = [n for n, r in roles.items() if 'entry_point' in r]
+    assert set(entry_points) == {'EntryA', 'EntryB', 'Iso'}
+    # There should be terminal nodes
+    terminal_nodes = [n for n, r in roles.items() if 'terminal_node' in r]
+    assert 'T1' in terminal_nodes and 'Iso' in terminal_nodes
+    # There should be at least one hub or utility or orphan
+    found_any = any('hub' in r or 'utility' in r or 'orphan_component_member' in r for r in roles.values())
+    assert found_any
+
+
 # 9. calculate_node_complexity_metrics
 def test_calculate_node_complexity_metrics_basic(simple_graph_no_cycles, da_test_logger: lg.Logger):
     calculate_node_complexity_metrics(simple_graph_no_cycles, da_test_logger)


### PR DESCRIPTION
Implements classify_nodes in analyzer.py to automatically assign architectural roles (hub, utility, orphan, entry, terminal) to nodes based on graph metrics and properties. Adds a CLI command for classification and a unit test for coverage.

- Adds classify_nodes function with percentile-based thresholds for role assignment.
- CLI command 'classify' updates graph files with node roles.
- Unit test ensures classification logic and node attributes.
- Supports optional complexity-based utility detection.

Closes #5 architectural node classification feature for dependency graphs.