### PR TITLE
✨feat(cli): Add CLI interface for `plsql_analyzer`

### DIFF
--- a/packages/plsql_analyzer/pyproject.toml
+++ b/packages/plsql_analyzer/pyproject.toml
@@ -13,10 +13,12 @@ dependencies = [
     "pyparsing[diagrams]>=3.2.3",
     "regex>=2024.11.6",
     "tqdm>=4.67.1",
+    "cyclopts>=0.4.6",
+    "tomlkit>=0.13.2",
 ]
 
 [project.scripts]
-plsql-analyzer = "plsql_analyzer:main"
+plsql-analyzer = "plsql_analyzer.cli:app"
 
 [build-system]
 requires = ["hatchling"]
@@ -31,4 +33,5 @@ dev = [
     "pytest-mock>=3.14.0",
     "pytest-xdist[psutil]>=3.6.1",
     "snakeviz>=2.2.2",
+    "tomlkit>=0.13.2",
 ]

--- a/packages/plsql_analyzer/src/plsql_analyzer/__init__.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/__init__.py
@@ -1,10 +1,7 @@
-# plsql_analyzer/main.py
-import cProfile
-import pstats
-import io
-from pathlib import Path
+# plsql_analyzer/__init__.py
+from __future__ import annotations
 
-from plsql_analyzer import config as cfg_module # Use an alias to avoid conflict
+from plsql_analyzer.settings import AppConfig
 from plsql_analyzer.utils.logging_setup import configure_logger
 from plsql_analyzer.utils.file_helpers import FileHelpers
 from plsql_analyzer.persistence.database_manager import DatabaseManager
@@ -13,89 +10,13 @@ from plsql_analyzer.parsing.signature_parser import PLSQLSignatureParser
 from plsql_analyzer.parsing.call_extractor import CallDetailExtractor
 from plsql_analyzer.orchestration.extraction_workflow import ExtractionWorkflow
 
-def main():
-    # Setting up Profiler
-    profiler = cProfile.Profile()
-    profiler.enable()
-
-    # Ensure artifact directories (logs, db) exist
-    config.ensure_artifact_dirs()
-
-    # 1. Configure Logger
-    logger = configure_logger(config.LOG_VERBOSE_LEVEL, config.LOGS_DIR)
-    logger.info(f"Application Started. Base directory: {config.BASE_DIR}")
-    logger.info(f"Artifacts will be stored in: {config.ARTIFACTS_DIR}")
-    logger.info(f"Source code configured from: {config.SOURCE_CODE_ROOT_DIR}")
-
-    # 2. Initialize Helper and Manager Classes
-    file_helpers = FileHelpers(logger)
-    
-    db_manager = DatabaseManager(config.DATABASE_PATH, logger)
-    try:
-        db_manager.setup_database() # Create tables if they don't exist
-    except Exception as e:
-        logger.critical(f"Database setup failed: {e}. Halting application.")
-        return # Stop if DB can't be set up
-
-    for fpath in config.REMOVE_FPATH:
-        db_manager.remove_file_record(fpath)
-        
-
-    # 3. Initialize Parsers
-    # Parsers are generally stateless or reset per call, so one instance can be reused.
-    structural_parser = PlSqlStructuralParser(logger, config.LOG_VERBOSE_LEVEL)
-    signature_parser = PLSQLSignatureParser(logger) # Does not depend on verbose_lvl for its own ops
-    call_extractor = CallDetailExtractor(logger, config.CALL_EXTRACTOR_KEYWORDS_TO_DROP)
-
-    # 4. Initialize and Run the Extraction Workflow
-    workflow = ExtractionWorkflow(
-        config=config, # Pass the config module/object
-        logger=logger,
-        db_manager=db_manager,
-        structural_parser=structural_parser,
-        signature_parser=signature_parser,
-        call_extractor=call_extractor,
-        file_helpers=file_helpers
-    )
-
-    try:
-        workflow.run()
-    except Exception as e:
-        logger.critical("Unhandled exception in the main extraction workflow. Application will exit.")
-        logger.exception(e)
-    finally:
-        logger.info("Application Finished.")
-    
-    profiler.disable()
-    s = io.StringIO()
-    ps = pstats.Stats(profiler, stream=s).sort_stats('cumulative')
-    ps.print_stats()
-    print(s.getvalue())
-
-    profiler.dump_stats(r"packages\plsql_analyzer\profiling_scripts\profile_plsql_analyzer_complete_run_v1-20250515.prof")
-
-if __name__ == "__main__":
-    # This allows running `python -m plsql_analyzer.main` if plsql_analyzer's parent is in PYTHONPATH
-    # Or if you are in the directory containing `plsql_analyzer` and run `python -m plsql_analyzer.main`
-    # If running `python plsql_analyzer/main.py` directly, imports might need adjustment
-    # (e.g. `from config import ...` if `plsql_analyzer` is the current working directory).
-    # The current relative imports `from . import config` assume `main.py` is run as part of the package.
-    
-    # For direct script execution from the project root (e.g., `python plsql_analyzer/main.py`):
-    # You might need to adjust PYTHONPATH or change imports to be relative to the script's location
-    # or use absolute package imports if `plsql_analyzer` is installed or in PYTHONPATH.
-    # One common way is to add the project root to sys.path if running script directly:
-    import sys
-    # Assuming main.py is in plsql_analyzer/ and project_root is parent of plsql_analyzer/
-    project_root = Path(__file__).resolve().parent.parent 
-    if str(project_root) not in sys.path:
-        sys.path.insert(0, str(project_root))
-    # After this, `from plsql_analyzer import config` should work.
-    # Re-importing with adjusted path (if necessary for direct script run)
-    
-    
-    # Re-assign config for the main function call if it was re-imported
-    global config
-    config = cfg_module
-
-    main()
+__all__ = [
+AppConfig,
+ExtractionWorkflow,
+DatabaseManager,
+PlSqlStructuralParser,
+PLSQLSignatureParser,
+CallDetailExtractor,
+FileHelpers,
+configure_logger,
+]

--- a/packages/plsql_analyzer/src/plsql_analyzer/cli.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/cli.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import io
+import pstats
+import cProfile
+import tomllib
+import cyclopts
+
+from pathlib import Path
+from typing import Optional, List, Sequence, Annotated, TYPE_CHECKING
+from cyclopts import App, Parameter, validators, Token
+
+from plsql_analyzer.settings import AppConfig
+from plsql_analyzer.utils.logging_setup import configure_logger
+from plsql_analyzer.utils.file_helpers import FileHelpers
+from plsql_analyzer.persistence.database_manager import DatabaseManager
+from plsql_analyzer.parsing.structural_parser import PlSqlStructuralParser
+from plsql_analyzer.parsing.signature_parser import PLSQLSignatureParser
+from plsql_analyzer.parsing.call_extractor import CallDetailExtractor
+from plsql_analyzer.orchestration.extraction_workflow import ExtractionWorkflow
+
+if TYPE_CHECKING:
+    from loguru import Logger
+
+app = App(help="PL/SQL Analyzer CLI")
+
+def convert_to_path(_, path_str:Sequence[Token]) -> Path:
+    """
+    Convert a string to a Path object.
+    """
+    
+    return Path(path_str[0].value)
+
+def validate_path(_, path: Optional[Path]):
+    """
+    Validate that the given path exists.
+    """
+    if path is None:
+        return
+    if not path.exists():
+        raise cyclopts.ValidationError(msg=f"Given Path `{path}` does not exist.\n")
+
+def fext_parser(_, fext: Sequence[Token]) -> List[str]:
+    """
+    Convert a list of file extensions to a list of strings.
+    """
+    return [ext.value.split(".")[1] if '.' in ext.value else ext.value for ext in fext]
+
+@app.command
+def parse(
+    source_dir: Annotated[Optional[Path], Parameter(help="Root directory of the source code.", converter=convert_to_path, validator=validate_path)],
+    config_file: Annotated[Optional[Path], Parameter(help="Path to the configuration file (TOML).", converter=convert_to_path, validator=validate_path)] = None,
+    output_dir: Annotated[Optional[Path], Parameter(help="Base directory for all generated artifacts.", converter=convert_to_path)] = None,
+    verbose: Annotated[int, Parameter(help="Verbosity level (0=ERROR, 1=INFO, 2=DEBUG, 3=TRACE).", name=["--verbose", "-v"], validator=validators.Number(gte=0, lte=3))] = 1,
+    profile: Annotated[Optional[bool], Parameter(help="Enable profiling.", name=["--profile"])] = None,
+    include_patterns: Annotated[Optional[List[str]], Parameter(help="File extensions to include in analysis.", name=["--fext", "-e"], consume_multiple=True, converter=fext_parser)] = None,
+    exclude_dirs: Annotated[Optional[List[str]], Parameter(help="Directory names to exclude from analysis.", name=["--exd"], consume_multiple=True)] = None,
+    exclude_names: Annotated[Optional[List[str]], Parameter(help="Directory names to exclude from package naming process.", name=["--exn"], consume_multiple=True)] = None,
+    database_filename: Annotated[Optional[str], Parameter(help="Name of the SQLite database file.", name=["--db-filename", "--dbf"])] = None,
+):
+    """
+    Parse PL/SQL source code to extract various code objects - Procedures and Function.
+    """
+    config_data = {}
+    if config_file:
+        if config_file.exists():
+            config_data = tomllib.loads(config_file.read_text())
+        else:
+            print(f"Warning: Config file {config_file} not found.")
+
+    # Precedence: Pydantic defaults < TOML file < CLI arguments
+    cli_args = {
+        "source_code_root_dir": source_dir,
+        "output_base_dir": output_dir,
+        "log_verbose_level": verbose,
+        "enable_profiler": profile,
+        "file_extensions_to_include": include_patterns,
+        "exclude_names_from_processed_path": exclude_dirs,
+        "exclude_names_for_package_derivation": exclude_names,
+        "database_filename": database_filename,
+    }
+
+    # Filter out None values from CLI args to not override TOML/defaults unnecessarily
+    cli_args_provided = {k: v for k, v in cli_args.items() if v is not None}
+
+    # Merge configurations: start with TOML, then override with CLI args
+    merged_config_data = {**config_data, **cli_args_provided}
+
+    try:
+        app_config = AppConfig(**merged_config_data)
+
+        # Configure logger using AppConfig
+        logger: Logger = configure_logger(app_config.log_verbose_level, app_config.logs_dir)
+        logger.info("Logger configured based on AppConfig.")
+        logger.info("Application Started.")
+        logger.info(f"Artifacts will be stored in: {app_config.artifacts_dir}")
+        logger.info(f"Source code configured from: {app_config.source_code_root_dir}")
+
+
+        app_config.ensure_artifact_dirs()
+
+        run_plsql_analyzer(app_config, logger)
+
+    except Exception as e:
+        print(f"Error initializing AppConfig or running analysis: {e}")
+        return
+
+
+def run_plsql_analyzer(app_config: AppConfig, logger:'Logger'):
+    logger.info(f"Starting PL/SQL analysis with source: {app_config.source_code_root_dir}")
+    
+    if app_config.enable_profiler:
+        profiler = cProfile.Profile()
+        profiler.enable()
+
+    # 2. Initialize Helper and Manager Classes
+    file_helpers = FileHelpers(logger)
+    
+    db_manager = DatabaseManager(app_config.database_path, logger)
+    try:
+        db_manager.setup_database() # Create tables if they don't exist
+    except Exception as e:
+        logger.critical(f"Database setup failed: {e}. Halting application.")
+        return # Stop if DB can't be set up
+
+    # TODO: Handle the removal of files from the database if needed
+    # for fpath in config.REMOVE_FPATH:
+    #     db_manager.remove_file_record(fpath)
+        
+
+    # 3. Initialize Parsers
+    # Parsers are generally stateless or reset per call, so one instance can be reused.
+    structural_parser = PlSqlStructuralParser(logger, app_config.log_verbose_level)
+    signature_parser = PLSQLSignatureParser(logger) # Does not depend on verbose_lvl for its own ops
+    call_extractor = CallDetailExtractor(logger, app_config.call_extractor_keywords_to_drop)
+
+    # 4. Initialize and Run the Extraction Workflow
+    workflow = ExtractionWorkflow(
+        config=app_config, # Pass the config module/object
+        logger=logger,
+        db_manager=db_manager,
+        structural_parser=structural_parser,
+        signature_parser=signature_parser,
+        call_extractor=call_extractor,
+        file_helpers=file_helpers
+    )
+
+    try:
+        workflow.run()
+    except Exception as e:
+        logger.critical("Unhandled exception in the main extraction workflow. Application will exit.")
+        logger.exception(e)
+    finally:
+        logger.info("Application Finished.")
+    
+    if app_config.enable_profiler:
+        profiler.disable()
+        s = io.StringIO()
+        ps = pstats.Stats(profiler, stream=s).sort_stats('cumulative')
+        ps.print_stats()
+        print(s.getvalue())
+
+        profiler.dump_stats(r"packages\plsql_analyzer\profiling_scripts\profile_plsql_analyzer_complete_run_v1-20250515.prof")
+
+
+if __name__ == "__main__":
+    app()

--- a/packages/plsql_analyzer/src/plsql_analyzer/cli.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/cli.py
@@ -102,7 +102,8 @@ def parse(
         run_plsql_analyzer(app_config, logger)
 
     except Exception as e:
-        print(f"Error initializing AppConfig or running analysis: {e}")
+        logger.error("Error initializing AppConfig or running analysis")
+        logger.exception(e)
         return
 
 
@@ -160,7 +161,7 @@ def run_plsql_analyzer(app_config: AppConfig, logger:'Logger'):
         ps.print_stats()
         print(s.getvalue())
 
-        profiler.dump_stats(r"packages\plsql_analyzer\profiling_scripts\profile_plsql_analyzer_complete_run_v1-20250515.prof")
+        profiler.dump_stats(app_config.output_base_dir / f"profile_plsql_analyzer-{app_config.source_code_root_dir.name}-{app_config.database_filename}.prof")
 
 
 if __name__ == "__main__":

--- a/packages/plsql_analyzer/src/plsql_analyzer/settings.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/settings.py
@@ -13,35 +13,43 @@ class AppConfig(BaseModel):
         default=Path("generated/artifacts").resolve(),
         description="Base directory for all generated artifacts, logs, and outputs."
     )
+
     log_verbose_level: int = Field(
         default=1,
         ge=0,
         le=3,
         description="Verbosity level for logging (0=ERROR, 1=INFO, 2=DEBUG, 3=TRACE)."
     )
-    log_file_prefix: str = Field(
-        default="dependency_debug_",
-        description="Prefix for log files."
-    )
-    log_trace_file_prefix: str = Field(
-        default="dependency_trace_",
-        description="Prefix for trace log files."
-    )
+
     database_filename: str = Field(
-        default="dependency_graph.db",
+        default="PLSQL_CodeObjects.db",
         description="Filename for the SQLite database storing analysis results."
     )
-    include_patterns: List[str] = Field(
-        default_factory=lambda: ["*.sql", "*.pls"],
+
+    file_extensions_to_include: List[str] = Field(
+        default_factory=lambda: ["sql"],
         description="Glob patterns for files to include in analysis."
     )
-    exclude_dirs: List[str] = Field(
-        default_factory=lambda: ["__pycache__", ".git", "tests", "logs"],
+
+    exclude_names_from_processed_path: List[str] = Field(
+        default_factory=lambda: [],
         description="Directory names to exclude from analysis."
     )
+
+    # Parts of the file path to exclude when deriving the package name from the file path.
+    exclude_names_for_package_derivation: List[str] = Field(
+        default_factory=lambda: ["PROCEDURES", "PACKAGE_BODIES", "FUNCTIONS"],
+        description="Directory names to exclude from package name derivation."
+    )
+
     enable_profiler: bool = Field(
         default=False,
         description="Enable or disable profiling during analysis."
+    )
+
+    call_extractor_keywords_to_drop: List[str] = Field(
+        default_factory=lambda: CALL_EXTRACTOR_KEYWORDS_TO_DROP,
+        description="List of keywords to drop during call extraction."
     )
 
     @property
@@ -50,7 +58,7 @@ class AppConfig(BaseModel):
 
     @property
     def logs_dir(self) -> Path:
-        return self.output_base_dir / "logs"
+        return self.output_base_dir / "logs" / "plsql_analyzer"
 
     @property
     def database_path(self) -> Path:
@@ -75,3 +83,187 @@ class AppConfig(BaseModel):
         expanded_path_str = os.path.expandvars(expanded_path_str)
         
         return Path(expanded_path_str).resolve()
+
+#  Keywords to drop during call extraction to reduce noise from common PL/SQL constructs
+# These are case-insensitive.
+CALL_EXTRACTOR_KEYWORDS_TO_DROP = [
+    # Aggregate Function:
+    "COUNT",
+    "SUM",
+    "AVG",
+    "MIN",
+    "MAX",
+    "LISTAGG",
+
+    # Analytic Function:
+    "ROW_NUMBER",
+    "RANK",
+    "DENSE_RANK",
+    "LAG",
+    "LEAD",
+
+    # Command:
+    "CREATE",
+    "ALTER",
+    "DROP",
+    "CREATE TABLE",
+    "ALTER TABLE",
+    "DROP TABLE",
+    "SELECT",
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "COMMIT",
+    "ROLLBACK",
+    "GRANT",
+    "REVOKE",
+    "MERGE",
+    "FROM",
+    "SAVEPOINT",
+    "CREATE OR REPLACE PROCEDURE",
+    "CREATE OR REPLACE FUNCTION",
+    "CREATE OR REPLACE PACKAGE",
+    "CREATE OR REPLACE TRIGGER",
+    "CREATE OR REPLACE VIEW",
+    "CREATE TYPE",
+
+    # Expression:
+    "CASE",
+
+    # Function:
+    "UPPER",
+    "LOWER",
+    "SUBSTR",
+    "INSTR",
+    "LENGTH",
+    "REPLACE",
+    "TRIM",
+    "ROUND",
+    "TRUNC",
+    "MOD",
+    "CEIL",
+    "FLOOR",
+    "SYSDATE",
+    "CURRENT_DATE",
+    "ADD_MONTHS",
+    "MONTHS_BETWEEN",
+    "LAST_DAY",
+    "EXTRACT",
+    "TO_CHAR",
+    "TO_DATE",
+    "TO_NUMBER",
+    "NVL",
+    "NVL2",
+    "COALESCE",
+    "DECODE",
+    "UTL_FILE.FOPEN",
+    "DBMS_RANDOM.VALUE",
+    "DBMS_RANDOM.STRING",
+    "DBMS_METADATA.GET_DDL",
+    "SQLCODE",
+    "SQLERRM",
+    "DBMS_LOB.GETLENGTH",
+    "DBMS_LOB.SUBSTR",
+    "DBMS_SQL.OPEN_CURSOR",
+    "DBMS_SQL.EXECUTE",
+
+    # Procedure:
+    "DBMS_OUTPUT.PUT_LINE",
+    "DBMS_OUTPUT.ENABLE",
+    "UTL_FILE.PUT_LINE",
+    "UTL_FILE.GET_LINE",
+    "UTL_FILE.FCLOSE",
+    "DBMS_LOCK.SLEEP",
+    "DBMS_SCHEDULER.CREATE_JOB",
+    "DBMS_SCHEDULER.RUN_JOB",
+    "RAISE_APPLICATION_ERROR",
+    "DBMS_SQL.PARSE",
+    "DBMS_SQL.CLOSE_CURSOR",
+
+    # PL/SQL Structure and Control Flow:
+    "DECLARE",
+    "BEGIN",
+    "END",
+    "IF",
+    "THEN",
+    "ELSIF",
+    "ELSE",
+    "END IF",
+    "LOOP",
+    "END LOOP",
+    "WHILE",
+    "FOR",
+    "IN",
+    "REVERSE",
+    "EXIT",
+    "CONTINUE",
+    "GOTO",
+    "RETURN",
+    "'NULL'",
+    "NULL",
+    "AND",
+    "OR",
+
+    # PL/SQL Declarations and Types:
+    "CONSTANT",
+    "DEFAULT",
+    "PROCEDURE",
+    "FUNCTION",
+    "PACKAGE",
+    "BODY",
+    "TYPE",
+    "SUBTYPE",
+    "RECORD",
+    "TABLE",
+    "VARRAY",
+    "IS",
+    "AS",
+    "PRAGMA",
+    "VARCHAR2",
+    "NVARCHAR2",
+    "NUMBER",
+    "PLS_INTEGER",
+    "BINARY_INTEGER",
+    "BINARY_FLOAT",
+    "BINARY_DOUBLE",
+    "BOOLEAN",
+    "DATE",
+    "TIMESTAMP",
+    "TIMESTAMP WITH TIME ZONE",
+    "TIMESTAMP WITH LOCAL TIME ZONE",
+    "INTERVAL YEAR TO MONTH",
+    "INTERVAL DAY TO SECOND",
+    "CLOB",
+    "NCLOB",
+    "BLOB",
+    "BFILE",
+    "ROWID",
+    "UROWID",
+    "CHAR",
+    "NCHAR",
+    "LONG",
+    "RAW",
+    "LONG RAW",
+
+    # PL/SQL Cursor Keywords:
+    "CURSOR",
+    "OPEN",
+    "FETCH",
+    "CLOSE",
+    "BULK COLLECT",
+    "FORALL",
+
+    # PL/SQL Exception Handling Keywords:
+    "EXCEPTION",
+    "WHEN",
+    "OTHERS",
+    "RAISE",
+
+    # PL/SQL Attributes:
+    "'%TYPE'",
+    "'%ROWTYPE'",
+    "'%FOUND'",
+    "'%NOTFOUND'",
+    "'%ROWCOUNT'",
+    "'%ISOPEN'",
+]

--- a/packages/plsql_analyzer/src/plsql_analyzer/utils/file_helpers.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/utils/file_helpers.py
@@ -113,7 +113,7 @@ class FileHelpers:
                     break
 
             if file_extension:
-                name_part = path_segment.replace(f'.{file_extension}', '')
+                name_part = Path(path_segment).stem
             else:
                 name_part = path_segment
 

--- a/packages/plsql_analyzer/src/plsql_analyzer/utils/file_helpers.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/utils/file_helpers.py
@@ -81,7 +81,7 @@ class FileHelpers:
     def derive_package_name_from_path(self,
                                    package_name_from_code: Optional[str],
                                    fpath: Path,
-                                   file_extension: str,
+                                   file_extensions: List[str],
                                    exclude_parts_for_pkg_derivation: List[str]) -> str:
         """
         Derives a package name from the file path, prepending parts of the
@@ -91,7 +91,7 @@ class FileHelpers:
         The final package name string is casefolded.
         """
 
-        self.logger.trace(f"Deriving package name for file '{fpath}'. Initial package from code: '{package_name_from_code}'. Excluding path parts: {exclude_parts_for_pkg_derivation}")
+        self.logger.trace(f"Deriving package name for file '{fpath}'. Initial package from code: '{package_name_from_code}'. Excluding path parts: {exclude_parts_for_pkg_derivation}. File extensions: {file_extensions}")
 
         # Normalize exclusion parts to lowercase for case-insensitive comparison
         exclude_parts_lower = [part.casefold() for part in exclude_parts_for_pkg_derivation]
@@ -105,7 +105,18 @@ class FileHelpers:
 
             # Remove file extension (if present) from the current path segment
             # NOTE: This logic might incorrectly remove parts of directory names if they match '.{file_extension}'
-            name_part = path_segment.split(f'.{file_extension}')[0]
+            file_extension = None
+            for ext in file_extensions:
+                if path_segment.endswith(f'.{ext}'):
+                    file_extension = ext
+                    self.logger.trace(f"File extension found: '{file_extension}' for segment '{path_segment}'")
+                    break
+
+            if file_extension:
+                name_part = path_segment.replace(f'.{file_extension}', '')
+            else:
+                name_part = path_segment
+
             if name_part != path_segment:
                 self.logger.trace(f"Segment '{path_segment}' potentially stripped extension to '{name_part}'")
 

--- a/packages/plsql_analyzer/tests/cli/test_cli.py
+++ b/packages/plsql_analyzer/tests/cli/test_cli.py
@@ -1,0 +1,281 @@
+import pytest
+import tomllib
+import tomlkit
+
+from pathlib import Path
+from plsql_analyzer.cli import app as cli_app
+from plsql_analyzer.settings import CALL_EXTRACTOR_KEYWORDS_TO_DROP
+
+@pytest.fixture
+def default_app_config_values():
+    # Provides default values from AppConfig for comparison
+    # Note: source_code_root_dir is required and has no Pydantic default.
+    return {
+        "output_base_dir": str(Path("generated/artifacts").resolve()),
+        "log_verbose_level": 1,
+        "database_filename": "PLSQL_CodeObjects.db",
+        "file_extensions_to_include": ["sql"],
+        "exclude_names_from_processed_path": [],
+        "exclude_names_for_package_derivation": ["PROCEDURES", "PACKAGE_BODIES", "FUNCTIONS"],
+        "enable_profiler": False,
+        "call_extractor_keywords_to_drop": CALL_EXTRACTOR_KEYWORDS_TO_DROP,
+    }
+
+@pytest.fixture
+def temp_config_file_all_fields(tmp_path: Path) -> Path:
+    config_content = {
+        "source_code_root_dir": str(tmp_path / "toml_sources"),
+        "output_base_dir": str(tmp_path / "toml_output"),
+        "log_verbose_level": 3,
+        "database_filename": "toml_db.sqlite",
+        "file_extensions_to_include": ["*.pkg", "*.pks"],
+        "exclude_names_from_processed_path": ["temp", "archive"],
+        "exclude_names_for_package_derivation": ["DEV_PACKAGES"],
+        "enable_profiler": True,
+        "call_extractor_keywords_to_drop": CALL_EXTRACTOR_KEYWORDS_TO_DROP,
+    }
+    config_file = tmp_path / "detailed_config.toml"
+    with open(config_file, "w") as f:
+        tomlkit.dump(config_content, f) # Use imported toml for writing
+
+    (tmp_path / "toml_sources").mkdir(exist_ok=True, parents=True)
+    (tmp_path / "toml_output").mkdir(exist_ok=True, parents=True)
+    return config_file
+
+@pytest.fixture
+def dummy_source_dir(tmp_path: Path) -> Path:
+    dir_path = tmp_path / "dummy_sources_cli"
+    dir_path.mkdir(exist_ok=True, parents=True)
+    (dir_path / "file1.sql").touch()
+    (dir_path / "file2.pkg").touch()
+    return dir_path
+
+@pytest.fixture
+def dummy_output_dir(tmp_path: Path) -> Path:
+    dir_path = tmp_path / "dummy_output_cli"
+    dir_path.mkdir(exist_ok=True, parents=True)
+    return dir_path
+
+@pytest.fixture
+def mock_run_plsql_analyzer(mocker):
+    return mocker.patch("plsql_analyzer.cli.run_plsql_analyzer")
+
+def test_cli_help_parse_command(capsys, mock_run_plsql_analyzer):
+    
+    cli_app(["parse", "--help"])
+    std_out = capsys.readouterr().out
+    assert "Usage: pytest parse" in std_out
+    assert "Parse PL/SQL source code" in std_out
+    assert "--source-dir" in std_out
+    assert "--output-dir" in std_out
+    assert "--config-file" in std_out
+    assert "--verbose" in std_out
+    assert "-v" in std_out
+    assert "--profile" in std_out
+    assert "--fext" in std_out
+    assert "--exd" in std_out
+    assert "--exn" in std_out
+    assert "--db-filename" in std_out
+    assert "--dbf" in std_out
+    # log_file_prefix and log_trace_file_prefix are CLI args, not directly in AppConfig help text
+    # but their corresponding AppConfig fields might be if they existed.
+
+def test_cli_parse_missing_source_dir_fails(capsys):
+    with pytest.raises(SystemExit) as e:
+        cli_app(["parse"])
+
+    std_out = capsys.readouterr().out
+    assert e.value.code != 0
+    assert "Command \"parse\" parameter \"--source-dir\" requires an argument." in std_out
+
+def test_path_converter_and_validator(capsys, tmp_path: Path):
+    # Test non-existent path
+    non_existent = tmp_path / "does_not_exist"
+    with pytest.raises(SystemExit) as e:
+        cli_app(["parse", "--source-dir", str(non_existent)])
+    
+    std_out = capsys.readouterr().out
+    assert "Path" in std_out
+    assert "does not exist" in std_out
+    assert e.value.code != 0
+
+    # Test valid path
+    valid_dir = tmp_path / "exists"
+    valid_dir.mkdir()
+    cli_app(["parse", "--source-dir", str(valid_dir)])
+    std_out = capsys.readouterr().out
+    assert "does not exist" not in std_out
+
+def test_cli_argument_aliases(capsys, dummy_source_dir, mocker):
+    # Mock the run_plsql_analyzer function to capture the config
+    mock_run = mocker.patch('plsql_analyzer.cli.run_plsql_analyzer')
+    
+    # Test file extension pattern
+    cli_app(["parse", "--source-dir", str(dummy_source_dir), "--fext", "sql"])
+    config_fext = mock_run.call_args[0][0]  # First argument to run_plsql_analyzer
+    assert ["sql"] == config_fext.file_extensions_to_include
+
+    # Test with -e alias
+    cli_app(["parse", "--source-dir", str(dummy_source_dir), "-e", "*.pkg"])
+    config_e = mock_run.call_args[0][0]  # First argument to run_plsql_analyzer
+    assert ["pkg"] == config_e.file_extensions_to_include
+
+    # Test multiple file extensions
+    cli_app(["parse", "--source-dir", str(dummy_source_dir), "--fext", "*.sql", ".pks"])
+    config_multiple_fext = mock_run.call_args[0][0]  # First argument to run_plsql_analyzer
+    assert sorted(["sql", "pks"]) == sorted(config_multiple_fext.file_extensions_to_include)
+
+    cli_app(["parse", "--source-dir", str(dummy_source_dir), "--fext", "*.sql", ".pks", "-e", "pkb"])
+    config_multiple_fext = mock_run.call_args[0][0]  # First argument to run_plsql_analyzer
+    assert sorted(["sql", "pks", "pkb"]) == sorted(config_multiple_fext.file_extensions_to_include)
+
+
+    # Test database filename aliases
+    cli_app(["parse", "--source-dir", str(dummy_source_dir), "--dbf", "test1.db"])
+    config_dbf = mock_run.call_args[0][0]  # First argument to run_plsql_analyzer
+    assert "test1.db" == config_dbf.database_filename
+
+    # Test with full name
+    cli_app(["parse", "--source-dir", str(dummy_source_dir), "--db-filename", "test2.db"])
+    config_db_filename = mock_run.call_args[0][0]
+    assert "test2.db" == config_db_filename.database_filename
+
+def test_cli_multiple_file_extensions(capsys, dummy_source_dir, mocker):
+    mock_run = mocker.patch('plsql_analyzer.cli.run_plsql_analyzer')
+    extensions = ["*.sql", ".pks", "pkb"]
+    cmd = ["parse", "--source-dir", str(dummy_source_dir)]
+    for ext in extensions:
+        cmd.extend(["--fext", ext])
+    
+    cli_app(cmd)
+    config = mock_run.call_args[0][0]
+    assert sorted(config.file_extensions_to_include) == sorted(["sql", "pks", "pkb"])
+
+def test_cli_exclude_dirs_and_names(capsys, dummy_source_dir, mocker):
+    mock_run = mocker.patch('plsql_analyzer.cli.run_plsql_analyzer')
+
+    # Test exclude_dirs (--exd)
+    exclude_dirs = ["temp", "test", "logs"]
+    cmd = ["parse", "--source-dir", str(dummy_source_dir)]
+    for d in exclude_dirs:
+        cmd.extend(["--exd", d])
+    
+    cli_app(cmd)
+    config = mock_run.call_args[0][0]
+    assert sorted(config.exclude_names_from_processed_path) == sorted(exclude_dirs)
+
+    # Test exclude_names (--exn)
+    exclude_names = ["PROCEDURES", "FUNCTIONS"]
+    cmd = ["parse", "--source-dir", str(dummy_source_dir)]
+    for n in exclude_names:
+        cmd.extend(["--exn", n])
+    
+    cli_app(cmd)
+    config = mock_run.call_args[0][0]
+    assert sorted(config.exclude_names_for_package_derivation) == sorted(exclude_names)
+
+def test_cli_verbosity_validation(capsys, dummy_source_dir, mocker):
+    mock_run = mocker.patch('plsql_analyzer.cli.run_plsql_analyzer')
+
+    # Test invalid verbosity level
+    with pytest.raises(SystemExit) as e:
+        cli_app(["parse", "--source-dir", str(dummy_source_dir), "--verbose", "4"])
+    std_out = capsys.readouterr().out
+    assert "Must be <= 3." in std_out
+    assert e.value.code != 0
+
+    with pytest.raises(SystemExit) as e:
+        cli_app(["parse", "--source-dir", str(dummy_source_dir), "--verbose", "-1"])
+    std_out = capsys.readouterr().out
+    assert "Must be >= 0." in std_out
+    assert e.value.code != 0
+
+    # Test valid verbosity levels
+    for level in range(4):
+        cli_app(["parse", "--source-dir", str(dummy_source_dir), "--verbose", str(level)])
+        config = mock_run.call_args[0][0]
+        assert config.log_verbose_level == level
+
+def test_cli_config_file_precedence(capsys, temp_config_file_all_fields, dummy_source_dir, mocker):
+    mock_run = mocker.patch('plsql_analyzer.cli.run_plsql_analyzer')
+    # Test that CLI args override config file values
+    cli_verbose = 0  # Config file has 3
+    cli_db = "cli.db"  # Config file has "toml_db.sqlite"
+    cli_extensions = ["*.proc"]  # Config file has ["*.pkg", "*.pks"]
+    
+    cmd = [
+        "parse",
+        "--source-dir", str(dummy_source_dir),  # Override source_dir from config
+        "--config-file", str(temp_config_file_all_fields),
+        "--verbose", str(cli_verbose),
+        "--db-filename", cli_db,
+        "--fext", cli_extensions[0],
+    ]
+    
+    cli_app(cmd)
+    config = mock_run.call_args[0][0]
+    
+    # CLI values should take precedence
+    assert config.log_verbose_level == cli_verbose
+    assert config.database_filename == cli_db
+    assert config.file_extensions_to_include == ["proc"]
+    assert config.source_code_root_dir == dummy_source_dir.resolve()
+
+    # Values from config file not overridden should remain
+    assert config.enable_profiler is True  # From config file
+
+def test_cli_empty_config_file(capsys, dummy_source_dir, tmp_path, mocker):
+    mock_run = mocker.patch('plsql_analyzer.cli.run_plsql_analyzer')
+    # Create an empty config file
+    empty_config = tmp_path / "empty.toml"
+    empty_config.touch()
+    
+    # Should work with defaults
+    cli_app(["parse", "--source-dir", str(dummy_source_dir), "--config-file", str(empty_config)])
+    config = mock_run.call_args[0][0]
+    
+    # Should use AppConfig defaults
+    assert config.log_verbose_level == 1
+    assert config.database_filename == "PLSQL_CodeObjects.db"
+    assert config.file_extensions_to_include == ["sql"]
+    assert not config.enable_profiler
+
+def test_cli_invalid_config_file(capsys, dummy_source_dir, tmp_path):
+    # Create an invalid TOML file
+    invalid_config = tmp_path / "invalid.toml"
+    invalid_config.write_text("this is not valid TOML]")
+    
+    with pytest.raises(tomllib.TOMLDecodeError):
+        cli_app(["parse", "--source-dir", str(dummy_source_dir), "--config-file", str(invalid_config)])
+
+
+def test_cli_paths_absolute_relative(capsys, dummy_source_dir, tmp_path, mocker):
+    mock_run = mocker.patch('plsql_analyzer.cli.run_plsql_analyzer')
+    # Test with relative paths
+    relative_source = Path("./src")
+    relative_output = Path("./output")
+    
+    # Create the directories
+    (tmp_path / "src").mkdir()
+    (tmp_path / "output").mkdir()
+    
+    # Change to tmp_path directory
+    import os
+    old_cwd = os.getcwd()
+    os.chdir(str(tmp_path))
+    
+    try:
+        cli_app(["parse", "--source-dir", str(relative_source), "--output-dir", str(relative_output)])
+        config = mock_run.call_args[0][0]
+        
+        # Paths should be resolved to absolute
+        assert config.source_code_root_dir.is_absolute()
+        assert config.output_base_dir.is_absolute()
+        
+        # Resolved paths should point to our temp directories
+        assert config.source_code_root_dir.resolve() == (tmp_path / "src").resolve()
+        assert config.output_base_dir.resolve() == (tmp_path / "output").resolve()
+    
+    finally:
+        os.chdir(old_cwd)
+

--- a/packages/plsql_analyzer/tests/test_settings.py
+++ b/packages/plsql_analyzer/tests/test_settings.py
@@ -7,11 +7,10 @@ def test_default_instantiation():
     assert config.source_code_root_dir == Path("/tmp").resolve()
     assert config.output_base_dir == Path("generated/artifacts").resolve()
     assert config.log_verbose_level == 1
-    assert config.log_file_prefix == "dependency_debug_"
-    assert config.log_trace_file_prefix == "dependency_trace_"
-    assert config.database_filename == "dependency_graph.db"
-    assert config.include_patterns == ["*.sql", "*.pls"]
-    assert config.exclude_dirs == ["__pycache__", ".git", "tests", "logs"]
+    assert config.database_filename == "PLSQL_CodeObjects.db"
+    assert config.file_extensions_to_include == ["sql"]
+    assert config.exclude_names_from_processed_path == []
+    assert config.exclude_names_for_package_derivation == ["PROCEDURES", "PACKAGE_BODIES", "FUNCTIONS"]
     assert config.enable_profiler is False
 
 def test_override_values():
@@ -19,27 +18,24 @@ def test_override_values():
         source_code_root_dir="src",
         output_base_dir="out",
         log_verbose_level=2,
-        log_file_prefix="log_",
-        log_trace_file_prefix="trace_",
         database_filename="test.db",
-        include_patterns=["*.foo"],
-        exclude_dirs=["bar"],
+        file_extensions_to_include=["*.foo"],
+        exclude_names_from_processed_path=["bar"],
         enable_profiler=True
     )
     assert config.source_code_root_dir == Path("src").resolve()
     assert config.output_base_dir == Path("out").resolve()
     assert config.log_verbose_level == 2
-    assert config.log_file_prefix == "log_"
-    assert config.log_trace_file_prefix == "trace_"
     assert config.database_filename == "test.db"
-    assert config.include_patterns == ["*.foo"]
-    assert config.exclude_dirs == ["bar"]
+    assert config.file_extensions_to_include == ["*.foo"]
+    assert config.exclude_names_from_processed_path == ["bar"]
+    assert config.exclude_names_for_package_derivation == ["PROCEDURES", "PACKAGE_BODIES", "FUNCTIONS"]
     assert config.enable_profiler is True
 
 def test_derived_properties():
     config = AppConfig(source_code_root_dir="/tmp", output_base_dir="/tmp/out", database_filename="foo.db")
     assert config.artifacts_dir == Path("/tmp/out").resolve()
-    assert config.logs_dir == Path("/tmp/out/logs").resolve()
+    assert config.logs_dir == Path("/tmp/out/logs/plsql_analyzer").resolve()
     assert config.database_path == Path("/tmp/out/foo.db").resolve()
 
 def test_ensure_artifact_dirs():

--- a/packages/plsql_analyzer/tests/utils/test_file_helpers.py
+++ b/packages/plsql_analyzer/tests/utils/test_file_helpers.py
@@ -61,12 +61,12 @@ class TestFileHelpers:
 
     # Tests for derive_package_name_from_path
     @pytest.mark.parametrize("pkg_from_code, fpath_str, file_ext, exclude_from_pkg_derivation, expected_pkg_name", [
-        (None, "project/src/moduleA/sub_mod_b/file.sql", "sql", ["project", "src"], "modulea.sub_mod_b.file"),
-        ("core_pkg", "project/src/core_pkg/file.sql", "sql", ["project", "src"], "core_pkg.file"),
-        (None, "project/src/file.sql", "sql", ["project", "src"], "file"), # No path parts left
-        ("mypkg", "file.sql", "sql", [], "mypkg.file"), # No path parts, only code
-        (None, "project/sources/PKG_OWNER/OBJECT_NAME.sql", "sql", ["project", "sources"], "pkg_owner.object_name"),
-        ("EXISTING", "project/module/file.sql", "sql", ["project", "module", "file"], "existing"),
+        (None, "project/src/moduleA/sub_mod_b/file.sql", ["sql"], ["project", "src"], "modulea.sub_mod_b.file"),
+        ("core_pkg", "project/src/core_pkg/file.sql", ["sql"], ["project", "src"], "core_pkg.file"),
+        (None, "project/src/file.sql", ["sql"], ["project", "src"], "file"), # No path parts left
+        ("mypkg", "file.sql", ["sql"], [], "mypkg.file"), # No path parts, only code
+        (None, "project/sources/PKG_OWNER/OBJECT_NAME.sql", ["sql"], ["project", "sources"], "pkg_owner.object_name"),
+        ("EXISTING", "project/module/file.sql", ["sql"], ["project", "module", "file"], "existing"),
     ])
     def test_derive_package_name_from_path(self, file_helpers_instance, pkg_from_code, fpath_str, file_ext, exclude_from_pkg_derivation, expected_pkg_name, mocker):
         # We need to mock Path behavior for parts and parent traversal


### PR DESCRIPTION
This commit introduces a command-line interface (CLI) for the `plsql_analyzer` package, leveraging the `cyclopts` library for argument parsing and `tomlkit` for configuration file management.

Key changes include:
-   **New CLI Module (`cli.py`):**
    -   Defines a `parse` command to initiate PL/SQL code analysis.
    -   Supports configuration via CLI arguments and a TOML configuration file.
    -   CLI arguments take precedence over TOML file settings, which in turn override Pydantic model defaults.
-   **Refactoring:**
    -   The main application logic previously in `plsql_analyzer/__init__.py` has been moved to `plsql_analyzer.cli.run_plsql_analyzer`.
    -   `plsql_analyzer/__init__.py` now primarily handles exports.
-   **Configuration (`settings.py`):**
    -   `AppConfig` updated with new fields (e.g., `file_extensions_to_include`, `exclude_names_from_processed_path`, `exclude_names_for_package_derivation`).
    -   Default values for some configuration options have been revised.
    -   `CALL_EXTRACTOR_KEYWORDS_TO_DROP` moved into `AppConfig`.
-   **Dependencies (`pyproject.toml`):**
    -   Added `cyclopts` and `tomlkit` as project dependencies.
    -   Updated the `plsql-analyzer` script entry point to `plsql_analyzer.cli:app`.
-   **Core Logic Updates:**
    -   `ExtractionWorkflow` now uses the updated `AppConfig` for settings like file extensions and exclusion paths.
    -   `FileHelpers.derive_package_name_from_path` modified to accept a list of file extensions.
-   **Testing:**
    -   Added new test suite `tests/cli/test_cli.py` for the CLI functionality.
    -   Updated `tests/test_settings.py` and `tests/utils/test_file_helpers.py` to reflect changes in `AppConfig` and `FileHelpers`.

This change enhances the usability and configurability of the `plsql_analyzer` tool.

This pr also closes #26 