### PR TITLE
✨ feat(plsql_analyzer): Add CLI options for force file reprocessing and history clearing

### DIFF
--- a/packages/plsql_analyzer/src/plsql_analyzer/cli.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/cli.py
@@ -80,8 +80,8 @@ def parse(
         "exclude_names_from_processed_path": exclude_dirs,
         "exclude_names_for_package_derivation": exclude_names,
         "database_filename": database_filename,
-        "force_reprocess": force_reprocess,
-        "clear_history_for_file": clear_history_for_file,
+        "force_reprocess": set(force_reprocess) if force_reprocess else None,
+        "clear_history_for_file": set(clear_history_for_file) if clear_history_for_file else None,
     }
 
     # Filter out None values from CLI args to not override TOML/defaults unnecessarily

--- a/packages/plsql_analyzer/src/plsql_analyzer/orchestration/extraction_workflow.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/orchestration/extraction_workflow.py
@@ -185,6 +185,7 @@ class ExtractionWorkflow:
         self.total_objects_failed_signature = 0
         self.total_objects_failed_calls = 0
         self.total_objects_failed_db_add = 0
+        self.total_files_force_reprocessed = 0
 
     def _escape_angle_brackets(self, text: str|list|dict) -> str:
 
@@ -221,13 +222,19 @@ class ExtractionWorkflow:
             return
 
         stored_hash = self.db_manager.get_file_hash(str(processed_fpath))
-
-        if stored_hash == current_file_hash:
+        
+        # Check if this file should be force reprocessed
+        force_reprocess = str(fpath) in self.config.force_reprocess or str(processed_fpath) in self.config.force_reprocess
+        if force_reprocess:
+            self.logger.info(f"Force reprocessing: {processed_fpath} (ignoring hash check)")
+            self.total_files_force_reprocessed += 1
+        elif stored_hash == current_file_hash:
             self.logger.info(f"Skipping (unchanged): {processed_fpath} (Hash: {current_file_hash[:10]}...)")
             self.total_files_skipped_unchanged +=1
             return
         
-        self.logger.info(f"Change detected (or new file): {processed_fpath} "
+        # If we're here, file is either changed, new, or forced to reprocess
+        self.logger.info(f"{'Force reprocessing' if force_reprocess else 'Change detected (or new file)'}: {processed_fpath} "
                          f"(Stored: {stored_hash[:10] if stored_hash else 'None'}, Current: {current_file_hash[:10]}...)")
 
         try:
@@ -242,6 +249,7 @@ class ExtractionWorkflow:
             return
 
         try:
+            print(clean_code)
             # Structural parsing returns package name found in code (if any) and dict of objects
             package_name_from_structural_parser, structurally_parsed_objects = self.structural_parser.parse(clean_code)
             structurally_parsed_objects: Dict
@@ -430,6 +438,7 @@ class ExtractionWorkflow:
         self.logger.info("--- Extraction Summary ---")
         self.logger.info(f"Total files processed: {self.total_files_processed}")
         self.logger.info(f"Files skipped (unchanged): {self.total_files_skipped_unchanged}")
+        self.logger.info(f"Files force reprocessed: {self.total_files_force_reprocessed}")
         self.logger.info(f"Files failed hashing: {self.total_files_failed_hash}")
         self.logger.info(f"Files failed structural parsing: {self.total_files_failed_structure_parse}")
         self.logger.info(f"Total code objects extracted and stored: {self.total_objects_extracted}")

--- a/packages/plsql_analyzer/src/plsql_analyzer/orchestration/extraction_workflow.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/orchestration/extraction_workflow.py
@@ -249,7 +249,6 @@ class ExtractionWorkflow:
             return
 
         try:
-            print(clean_code)
             # Structural parsing returns package name found in code (if any) and dict of objects
             package_name_from_structural_parser, structurally_parsed_objects = self.structural_parser.parse(clean_code)
             structurally_parsed_objects: Dict

--- a/packages/plsql_analyzer/src/plsql_analyzer/settings.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/settings.py
@@ -47,13 +47,13 @@ class AppConfig(BaseModel):
         description="Enable or disable profiling during analysis."
     )
     
-    force_reprocess: List[str] = Field(
-        default_factory=list,
+    force_reprocess: set[str] = Field(
+        default_factory=set,
         description="List of file paths to force reprocess, bypassing hash checks."
     )
     
-    clear_history_for_file: List[str] = Field(
-        default_factory=list,
+    clear_history_for_file: set[str] = Field(
+        default_factory=set,
         description="List of processed file paths to clear history for from the database."
     )
 

--- a/packages/plsql_analyzer/src/plsql_analyzer/settings.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/settings.py
@@ -46,6 +46,16 @@ class AppConfig(BaseModel):
         default=False,
         description="Enable or disable profiling during analysis."
     )
+    
+    force_reprocess: List[str] = Field(
+        default_factory=list,
+        description="List of file paths to force reprocess, bypassing hash checks."
+    )
+    
+    clear_history_for_file: List[str] = Field(
+        default_factory=list,
+        description="List of processed file paths to clear history for from the database."
+    )
 
     call_extractor_keywords_to_drop: List[str] = Field(
         default_factory=lambda: CALL_EXTRACTOR_KEYWORDS_TO_DROP,

--- a/packages/plsql_analyzer/tests/orchestration/test_extraction_workflow.py
+++ b/packages/plsql_analyzer/tests/orchestration/test_extraction_workflow.py
@@ -3,6 +3,10 @@ import loguru as lg
 import pytest
 from plsql_analyzer.orchestration.extraction_workflow import clean_code_and_map_literals
 
+# Additional imports for testing the ExtractionWorkflow class
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from plsql_analyzer.orchestration.extraction_workflow import ExtractionWorkflow
 
 # --- Test Cases ---
 @pytest.mark.parametrize("input_code, expected_cleaned_code, expected_mapping", [
@@ -85,3 +89,74 @@ def test_q_quoted_strings_not_specially_handled(test_logger):
     cleaned_code_2, mapping_2 = clean_code_and_map_literals(code_2, test_logger)
     assert cleaned_code_2 == expected_cleaned_2
     assert mapping_2 == expected_mapping_2
+
+def test_extraction_workflow_force_reprocess(test_logger):
+    """Test that force_reprocess from the AppConfig is correctly handled in _process_single_file."""
+    
+    mock_db_manager = MagicMock()
+    mock_db_manager.get_file_hash.return_value = "current_hash_123"
+    
+    mock_file_helpers = MagicMock()
+    mock_file_helpers.get_processed_fpath.return_value = "processed/path/file.sql"
+    mock_file_helpers.compute_file_hash.return_value = "current_hash_123"
+    mock_file_helpers.escape_angle_brackets = lambda x: x  # Simple passthrough
+    
+    # Other mocks needed for the workflow
+    mock_structural_parser = MagicMock()
+    mock_structural_parser.parse.return_value = ("", {})
+    mock_signature_parser = MagicMock()
+    mock_call_extractor = MagicMock()
+    
+    # Create two workflow instances with different configs
+    # Config for normal processing
+    mock_config_normal = MagicMock()
+    mock_config_normal.force_reprocess = []
+    
+    # Config for forced reprocessing
+    mock_config_force = MagicMock()
+    mock_config_force.force_reprocess = ["/path/to/file.sql", "processed/path/file.sql"]
+    
+    workflow_normal = ExtractionWorkflow(
+        config=mock_config_normal,
+        logger=test_logger,
+        db_manager=mock_db_manager,
+        structural_parser=mock_structural_parser,
+        signature_parser=mock_signature_parser,
+        call_extractor=mock_call_extractor,
+        file_helpers=mock_file_helpers
+    )
+    
+    workflow_force = ExtractionWorkflow(
+        config=mock_config_force,
+        logger=test_logger,
+        db_manager=mock_db_manager,
+        structural_parser=mock_structural_parser,
+        signature_parser=mock_signature_parser,
+        call_extractor=mock_call_extractor,
+        file_helpers=mock_file_helpers
+    )
+    
+    # Test cases
+    test_file_path = Path("/path/to/file.sql")
+    
+    # Case 1: Normal workflow with matching hash should skip processing
+    with patch('builtins.open'):  # Prevent actual file opening
+        workflow_normal._process_single_file(test_file_path)
+    
+    # Verify skipped due to hash match
+    assert workflow_normal.total_files_skipped_unchanged == 1
+    assert workflow_normal.total_files_processed == 0
+    assert workflow_normal.total_files_force_reprocessed == 0
+    
+    # Case 2: Force workflow with matching hash should continue processing
+    # We need to patch functions that would be called by _process_single_file after the hash check
+    with patch('builtins.open', MagicMock()):
+        with patch.object(workflow_force, 'db_manager') as mock_db:
+            # Override update_file_hash to avoid needing to mock all subsequent code
+            mock_db.update_file_hash.return_value = "current_hash_123"
+            workflow_force._process_single_file(test_file_path)
+    
+    # Verify processing was forced despite hash match
+    assert workflow_force.total_files_skipped_unchanged == 0
+    assert workflow_force.total_files_force_reprocessed == 1
+    assert workflow_force.total_files_processed == 1


### PR DESCRIPTION
Add options to the CLI interface for more granular control of file processing:
- `--force-reprocess` to bypass hash checks and force reprocessing of specific files
- `--clear-history-for-file` to remove specified file records and associated objects from the database

Also removes legacy TODO comments related to file removal and enhances logging with a counter for forced reprocessed files in the workflow summary.

Fixes #28