### PR TITLE
📚 docs(plsql-analyzer): Update documentation for CLI and TOML configuration

### DIFF
--- a/packages/plsql_analyzer/README.md
+++ b/packages/plsql_analyzer/README.md
@@ -1,5 +1,4 @@
 # PL/SQL Analyzer (`plsql-analyzer`)
-# PL/SQL Analyzer (`plsql-analyzer`)
 
 ## Overview
 
@@ -15,7 +14,7 @@ This package is a core component of the CodeMorph project, aimed at facilitating
 *   **Code Cleaning**: Preprocesses PL/SQL code by removing comments and replacing string literals with placeholders to simplify parsing.
 *   **Persistent Storage**: Stores extracted metadata and file processing status in a SQLite database using `DatabaseManager`.
 *   **Change Detection**: Processes only new or modified files based on their content hash.
-*   **Configurable**: Behavior can be customized through `config.py` (e.g., source directories, file extensions, keywords to ignore).
+*   **Configurable**: Behavior can be customized through a TOML configuration file or CLI arguments.
 *   **Logging**: Comprehensive logging using `loguru` for diagnostics and tracing.
 *   **Profiling Scripts**: Includes scripts to profile the performance of key parsing components.
 *   **Unit Tested**: Comes with a suite of unit tests using `pytest`.
@@ -79,47 +78,75 @@ The package is managed using a `pyproject.toml` file.
     pip install .[dev]
     ```
 
-## Configuration
-
-The primary configuration for the `plsql-analyzer` is managed in [`src/plsql_analyzer/config.py`](src/plsql_analyzer/config.py). Key settings include:
-
-*   `BASE_DIR`: Base directory for generated artifacts.
-*   `ARTIFACTS_DIR`: Directory for storing artifacts like logs and the database.
-*   `LOGS_DIR`: Specific directory for log files.
-*   `DATABASE_PATH`: Path to the SQLite database file.
-*   `SOURCE_CODE_ROOT_DIR`: Path to the root directory of your PL/SQL source code. **This needs to be configured by the user.**
-*   `FILE_EXTENSION`: The file extension(s) to scan for PL/SQL files (e.g., "sql", "pks", "pkb").
-*   `LOG_VERBOSE_LEVEL`: Controls console logging verbosity (0=WARNING, 1=INFO, 2=DEBUG, 3=TRACE).
-*   `EXCLUDE_FROM_PROCESSED_PATH`: List of path segments to exclude when forming processed file paths for database records.
-*   `EXCLUDE_FROM_PATH_FOR_PACKAGE_DERIVATION`: List of path segments to exclude when deriving package names from file paths.
-*   `CALL_EXTRACTOR_KEYWORDS_TO_DROP`: A list of PL/SQL keywords to ignore during call extraction to reduce noise.
-*   `REMOVE_FPATH`: A list of specific file paths to remove/ignore from processing.
-
-Modify [`src/plsql_analyzer/config.py`](src/plsql_analyzer/config.py) to suit your environment and PL/SQL codebase.
-
 ## Usage
 
-The `plsql-analyzer` can be run as a script, which will initiate the extraction workflow:
+The primary way to use the PL/SQL Analyzer is through its command-line interface (CLI):
 
 ```bash
-python -m plsql_analyzer
-```
-Alternatively, if the package is installed and the script `plsql-analyzer` is in your PATH (as defined in pyproject.toml):
-```bash
-plsql-analyzer
+plsql-analyzer analyze [OPTIONS]
 ```
 
-The main workflow will:
-1.  Configure logging.
-2.  Initialize the database and ensure the schema is set up.
-3.  Scan the `SOURCE_CODE_ROOT_DIR` for PL/SQL files.
-4.  For each new or modified file (based on hash comparison):
-    *   Clean the code (remove comments, replace literals).
-    *   Perform structural parsing to identify code objects.
-    *   Perform signature parsing for procedures and functions.
-    *   Extract calls made by each object.
-    *   Store the extracted `PLSQL_CodeObject` instances in the database.
-5.  Log a summary of the extraction process.
+### CLI Options
+
+The following options are available for the `analyze` command:
+
+*   `--source-dir DIRECTORY`: Specifies the root directory containing the PL/SQL source code to be analyzed.
+    *   Example: `plsql-analyzer analyze --source-dir ./my_plsql_project/src`
+*   `--output-dir DIRECTORY`: Specifies the base directory where analysis artifacts (database, logs, etc.) will be stored.
+    *   Example: `plsql-analyzer analyze --output-dir ./analysis_results`
+*   `--config-file FILE`: Specifies the path to a custom configuration TOML file. If not provided, the tool looks for `plsql_analyzer_config.toml` in the current directory.
+    *   Example: `plsql-analyzer analyze --config-file ./custom_config.toml`
+*   `-v, --verbose INTEGER`: Sets the verbosity level for logging.
+    *   `0`: ERROR
+    *   `1`: INFO (default)
+    *   `2`: DEBUG
+    *   `3`: TRACE
+    *   Example: `plsql-analyzer analyze -v 2`
+*   `--profile / --no-profile`: Enables or disables performance profiling of the analyzer. Defaults to `no-profile`.
+    *   Example: `plsql-analyzer analyze --profile`
+*   `--force-reprocess TEXT`: A comma-separated list of file paths (relative to `source-dir`) that should be reprocessed even if they haven't changed since the last analysis.
+    *   Example: `plsql-analyzer analyze --force-reprocess "schema1/package1.pkb,schema2/procedure1.sql"`
+*   `--clear-history-for-file TEXT`: A comma-separated list of file paths (relative to `source-dir`) for which historical processing records should be cleared before analysis. This is useful if a file's history is corrupted or needs a fresh start.
+    *   Example: `plsql-analyzer analyze --clear-history-for-file "schema1/old_package.pks"`
+
+## Configuration
+
+### Configuration File (`plsql_analyzer_config.toml`)
+
+The PL/SQL Analyzer can be configured using a TOML file, typically named `plsql_analyzer_config.toml`.
+
+*   **Purpose**: The TOML configuration file allows you to set various parameters for the analysis process, providing more granular control than CLI arguments alone.
+*   **Default Location**: The tool looks for `plsql_analyzer_config.toml` in the current working directory by default. You can specify a different location using the `--config-file` CLI option.
+*   **Interaction with CLI Arguments**: CLI arguments generally override the corresponding settings in the configuration file. For example, if `source_code_root_dir` is set in the TOML file and `--source-dir` is also provided on the command line, the CLI value will be used.
+
+### Key Configuration Parameters
+
+Here are some of the key parameters you can set in `plsql_analyzer_config.toml`:
+
+*   `source_code_root_dir` (string): The root directory of your PL/SQL source code.
+    *   Example: `source_code_root_dir = "project/sql_sources"`
+*   `output_base_dir` (string): The directory where output artifacts (like the analysis database and logs) will be saved.
+    *   Example: `output_base_dir = "analysis_output"`
+*   `file_extensions_to_include` (array of strings): A list of file extensions to be considered as PL/SQL files.
+    *   Example: `file_extensions_to_include = ["sql", "pks", "pkb", "fnc", "prc"]`
+*   `log_verbose_level` (integer): Sets the logging verbosity (0=ERROR, 1=INFO, 2=DEBUG, 3=TRACE).
+    *   Example: `log_verbose_level = 1`
+*   `database_filename` (string): The name of the SQLite database file where analysis results will be stored.
+    *   Example: `database_filename = "plsql_analysis.db"`
+*   `exclude_names_from_processed_path` (array of strings): A list of directory or file name patterns to exclude from processing. This helps in ignoring irrelevant files or temporary directories.
+    *   Example: `exclude_names_from_processed_path = [".svn", "temp_files"]`
+*   `exclude_names_for_package_derivation` (array of strings): A list of directory names to exclude when trying to derive a package name from a file's path. For instance, if your files are in `packages/my_pkg/file.sql`, and `packages` is in this list, `my_pkg` might be considered part of the package name.
+    *   Example: `exclude_names_for_package_derivation = ["PACKAGE_BODIES", "PROCEDURES"]`
+*   `enable_profiler` (boolean): Set to `true` to enable performance profiling of the analyzer.
+    *   Example: `enable_profiler = false`
+*   `call_extractor_keywords_to_drop` (array of strings): A list of keywords that should be ignored by the call extractor. This is useful for filtering out common SQL functions or keywords that are not relevant for dependency analysis.
+    *   Example: `call_extractor_keywords_to_drop = ["COUNT", "SUM", "DBMS_OUTPUT.PUT_LINE"]`
+*   `force_reprocess` (array of strings, optional): A list of file paths (relative to `source_code_root_dir`) to force reprocess.
+    *   Example: `force_reprocess = ["schema_app_core/functions/is_employee_active.sql"]`
+*   `clear_history_for_file` (array of strings, optional): A list of file paths (relative to `source_code_root_dir`) to clear processing history for.
+    *   Example: `clear_history_for_file = ["schema_app_core/procedures/old_unused_procedure.sql"]`
+
+See the example `plsql_analyzer_config.toml` in the project root for more details and default values.
 
 ## Core Components
 

--- a/packages/plsql_analyzer/README.md
+++ b/packages/plsql_analyzer/README.md
@@ -94,7 +94,7 @@ The following options are available for the `analyze` command:
     *   Example: `plsql-analyzer analyze --source-dir ./my_plsql_project/src`
 *   `--output-dir DIRECTORY`: Specifies the base directory where analysis artifacts (database, logs, etc.) will be stored.
     *   Example: `plsql-analyzer analyze --output-dir ./analysis_results`
-*   `--config-file FILE`: Specifies the path to a custom configuration TOML file. If not provided, the tool looks for `plsql_analyzer_config.toml` in the current directory.
+*   `--config-file FILE`: Specifies the path to a custom configuration TOML file. If not provided falls back to default values or other cli options given.
     *   Example: `plsql-analyzer analyze --config-file ./custom_config.toml`
 *   `-v, --verbose INTEGER`: Sets the verbosity level for logging.
     *   `0`: ERROR
@@ -116,7 +116,7 @@ The following options are available for the `analyze` command:
 The PL/SQL Analyzer can be configured using a TOML file, typically named `plsql_analyzer_config.toml`.
 
 *   **Purpose**: The TOML configuration file allows you to set various parameters for the analysis process, providing more granular control than CLI arguments alone.
-*   **Default Location**: The tool looks for `plsql_analyzer_config.toml` in the current working directory by default. You can specify a different location using the `--config-file` CLI option.
+*   **Location**: You can specify a different location using the `--config-file` CLI option.
 *   **Interaction with CLI Arguments**: CLI arguments generally override the corresponding settings in the configuration file. For example, if `source_code_root_dir` is set in the TOML file and `--source-dir` is also provided on the command line, the CLI value will be used.
 
 ### Key Configuration Parameters

--- a/packages/plsql_analyzer/docs/plsql_analyzer_config_example.toml
+++ b/packages/plsql_analyzer/docs/plsql_analyzer_config_example.toml
@@ -1,0 +1,144 @@
+# PL/SQL Analyzer Configuration Example
+# This file provides a comprehensive example of how to configure the PL/SQL Analyzer.
+# Settings in this file can be overridden by command-line arguments.
+
+# Core configuration fields
+# -------------------------
+# source_code_root_dir: Specifies the root directory containing the PL/SQL source code.
+# This is a **required** field if not provided via the --source-dir CLI argument.
+source_code_root_dir = "./my_project/plsql_sources" 
+
+# output_base_dir: Specifies the base directory where analysis artifacts (database, logs, etc.) will be stored.
+# This is a **required** field if not provided via the --output-dir CLI argument.
+output_base_dir = "./analysis_output"
+
+# Logging and verbosity
+# ---------------------
+# log_verbose_level: Sets the verbosity level for logging.
+#   0 = ERROR: Only errors are logged.
+#   1 = INFO: Informational messages, warnings, and errors are logged (default).
+#   2 = DEBUG: Detailed debugging information is logged.
+#   3 = TRACE: Very verbose logging, including parser rule entry/exit (for deep debugging).
+log_verbose_level = 1  # Default: 1 (INFO)
+
+# Database settings
+# -----------------
+# database_filename: The name of the SQLite database file where analysis results will be stored.
+# This file will be created within the 'output_base_dir'.
+database_filename = "PLSQL_CodeObjects.db"  # Default: "PLSQL_CodeObjects.db"
+
+# File selection patterns
+# -----------------------
+# file_extensions_to_include: A list of file extensions that the analyzer should consider as PL/SQL files.
+# The analyzer will scan for files with these extensions within the 'source_code_root_dir'.
+file_extensions_to_include = [
+    "sql",   # Standard SQL files
+    "pks",   # Package specifications
+    "pkb",   # Package bodies
+    "fnc",   # Functions (if stored separately)
+    "prc",   # Procedures (if stored separately)
+    "trg"    # Triggers
+]
+
+# Directory and file exclusions
+# -----------------------------
+# exclude_names_from_processed_path: A list of directory or file name patterns to exclude from processing.
+# This is useful for ignoring version control directories, temporary files, or specific sub-projects.
+# Patterns are matched against parts of the file path.
+# Example: If you have "src/.svn/some_file.sql", adding ".svn" here will exclude it.
+exclude_names_from_processed_path = [
+    ".git",           # Git version control
+    ".svn",           # SVN version control
+    "temp",           # Temporary files
+    "__pycache__",    # Python cache files
+    "old_versions",   # Legacy code archives
+    "test_data"       # Test data that should be ignored
+]
+
+# exclude_names_for_package_derivation: A list of directory names to exclude when the analyzer
+# attempts to derive a package name from a file's path.
+# For example, if your PL/SQL files are organized like 'schema_name/packages/my_package.pks',
+# and you include "packages" in this list, the analyzer might derive 'schema_name.my_package'
+# instead of 'schema_name.packages.my_package'.
+# This helps in creating more natural package/object names.
+exclude_names_for_package_derivation = [
+    "PROCEDURES",      # Common directory name for procedures
+    "PACKAGE_BODIES",  # Directory for package bodies
+    "FUNCTIONS",       # Common directory name for functions
+    "PACKAGES",        # Common directory name for packages
+    "TRIGGERS",        # Common directory name for triggers
+    "VIEWS",           # Common directory name for views
+    "TYPES",           # Common directory name for types
+    "SOURCE",          # Generic source code directory
+    "SQL"              # Generic SQL directory
+]
+
+# Performance settings
+# --------------------
+# enable_profiler: Set to true to enable performance profiling of the analyzer.
+# Profiling results are typically saved in the logs directory and can help identify bottlenecks.
+# This can also be controlled by the --profile / --no-profile CLI flags.
+enable_profiler = false  # Default: false
+
+# Processing control (optional)
+# -----------------------------
+# These settings allow for fine-grained control over how specific files are processed.
+# They are typically used for debugging or handling problematic files.
+
+# force_reprocess: A list of file paths (relative to 'source_code_root_dir') that should be
+# reprocessed even if they haven't changed since the last analysis.
+# Useful if you suspect an issue with a previous analysis of a specific file.
+# This can also be set via the --force-reprocess CLI argument (comma-separated).
+force_reprocess = [
+  "schema_app_core/functions/is_employee_active.sql",
+  "schema_app_finance/packages/payroll_pkg.pkb"
+]
+
+# clear_history_for_file: A list of file paths (relative to 'source_code_root_dir') for which
+# historical processing records (e.g., last processed timestamp, hash) should be cleared
+# before the analysis. This forces a completely fresh processing of these files.
+# Useful if a file's processing history is corrupted or needs a clean slate.
+# This can also be set via the --clear-history-for-file CLI argument (comma-separated).
+clear_history_for_file = [
+  "schema_app_core/procedures/old_unused_procedure.sql"
+]
+
+# Call extractor keywords to drop
+# -------------------------------
+# call_extractor_keywords_to_drop: A list of keywords (typically function or procedure names)
+# that should be ignored by the call extractor during dependency analysis.
+# This is useful for filtering out calls to very common built-in functions, standard library
+# packages (like DBMS_OUTPUT), or other items that are not relevant for the specific
+# dependency graph you want to generate.
+
+call_extractor_keywords_to_drop = [
+  # Common SQL aggregate functions
+  "COUNT", "SUM", "AVG", "MIN", "MAX",
+  
+  # Common SQL string manipulation functions
+  "SUBSTR", "INSTR", "LENGTH", "LOWER", "UPPER", "TRIM", "LTRIM", "RTRIM", "REPLACE",
+  
+  # Common SQL date functions
+  "TO_DATE", "TO_CHAR", "SYSDATE", "ADD_MONTHS", "MONTHS_BETWEEN", "NEXT_DAY", "LAST_DAY",
+  
+  # Common SQL conversion/coalesce functions
+  "TO_NUMBER", "NVL", "NVL2", "COALESCE", "NULLIF", "DECODE",
+  
+  # Common SQL operators that might be detected as function calls
+  "IN", "EXISTS", "BETWEEN", "LIKE",
+  
+  # Oracle built-in package procedures/functions 
+  "DBMS_OUTPUT.PUT_LINE", "DBMS_OUTPUT.PUT", "DBMS_OUTPUT.NEW_LINE",
+  "DBMS_LOCK.SLEEP",
+  "UTL_FILE.FOPEN", "UTL_FILE.PUT_LINE", "UTL_FILE.FCLOSE",
+  
+  # Add your project-specific keywords to ignore here
+  # "MY_COMMON_LOGGING_PROCEDURE",
+  # "INTERNAL_HELPER_FUNCTION"
+]
+
+# Other Settings
+# -------------
+# Add any additional custom settings below this point
+# custom_setting_1 = "value"
+# custom_setting_2 = 123


### PR DESCRIPTION
Added comprehensive documentation for the PL/SQL Analyzer CLI and TOML configuration:

- Enhanced README.md in packages/plsql_analyzer with detailed CLI options
- Added Configuration section explaining TOML parameters and their usage
- Created well-commented example configuration in docs/plsql_analyzer_config_example.toml

Closes #33 