### PR TITLE
🐛 fix: Update _extract_call_params to return Optional[CallParameterTu…

### DIFF
--- a/packages/plsql_analyzer/src/plsql_analyzer/parsing/call_extractor.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/parsing/call_extractor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import loguru as lg
 import pyparsing as pp
-from typing import List, Tuple, Dict, NamedTuple
+from typing import List, Optional, Tuple, Dict, NamedTuple
 
 from plsql_analyzer.utils.text_utils import escape_angle_brackets
 
@@ -193,7 +193,7 @@ class CallDetailExtractor:
         self.logger.debug(f"Found {len(extracted_calls_list)} potential calls in code block.")
         return extracted_calls_list
 
-    def _extract_call_params(self, call_info: ExtractedCallTuple) -> CallParameterTuple:
+    def _extract_call_params(self, call_info: ExtractedCallTuple) -> Optional[CallParameterTuple]:
         """
         Extracts parameters for a given call from the cleaned code.
         Based on the user-provided `extract_call_params` function.

--- a/packages/plsql_analyzer/tests/parsing/test_call_extractor.py
+++ b/packages/plsql_analyzer/tests/parsing/test_call_extractor.py
@@ -159,7 +159,7 @@ def test_extract_calls_with_details(extractor:CallDetailExtractor, code, expecte
     """Tests the main public method with various PL/SQL snippets."""
 
     clean_code, literal_map = clean_code_and_map_literals(code, extractor.logger)
-    results = extractor.extract_calls_with_details(clean_code, literal_map)
+    results = extractor.extract_calls_with_details(clean_code, literal_map, allow_parameterless=True)
     
     # Convert results to a comparable format (ignoring indices for simplicity in some cases if needed)
     # For now, compare everything including indices.


### PR DESCRIPTION
…ple] and modify test to allow parameterless calls