### PR TITLE
✨feat(plsql_analyzer): Add `strict_lpar_only_calls` feature for granular call detection

### DIFF
--- a/packages/plsql_analyzer/docs/plsql_analyzer_config_example.toml
+++ b/packages/plsql_analyzer/docs/plsql_analyzer_config_example.toml
@@ -139,6 +139,15 @@ call_extractor_keywords_to_drop = [
 
 # Other Settings
 # -------------
+# Allow parameterless calls: Whether to extract calls that do not have parameters.
+# Example: `my_procedure;` or `SYSDATE` vs only extracting `my_procedure()` patterns.
+allow_parameterless_calls = false
+
+# Strict LPAR only calls: When true, only identifiers followed by '(' are considered calls,
+# ignoring ';' terminated identifiers during initial parsing. This reduces false positives
+# for users who only want `name(...)` syntax as calls.
+strict_lpar_only_calls = false
+
 # Add any additional custom settings below this point
 # custom_setting_1 = "value"
 # custom_setting_2 = 123

--- a/packages/plsql_analyzer/src/plsql_analyzer/settings.py
+++ b/packages/plsql_analyzer/src/plsql_analyzer/settings.py
@@ -67,6 +67,11 @@ class PLSQLAnalyzerSettings(BaseModel):
         description="Whether to extract calls that do not have parameters, e.g., `my_procedure;` or `SYSDATE`."
     )
 
+    strict_lpar_only_calls: bool = Field(
+        default=False,
+        description="When True, only identifiers followed by '(' are considered calls, ignoring ';' terminated identifiers during initial parsing"
+    )
+
     @computed_field
     def artifacts_dir(self) -> Path:
         return self.output_base_dir


### PR DESCRIPTION
Implements a new `strict_lpar_only_calls` configuration option that provides users with finer-grained control over call detection by only considering identifiers followed by '(' as calls, effectively ignoring ';' terminated identifiers during initial parsing.

## Changes Made:

- **Settings**: Added `strict_lpar_only_calls` boolean field to `PLSQLAnalyzerSettings` (default: False)
- **Call Extractor**: Modified `CallDetailExtractor` to accept and use the new setting in grammar construction
- **CLI**: Added `--strict-calls`/`--no-strict-calls` command-line options for runtime control
- **Documentation**: Updated example TOML config with both `allow_parameterless_calls` and `strict_lpar_only_calls` settings
- **Tests**: Comprehensive test coverage including parameterized tests for various combinations, CLI option tests, and settings validation tests

## Benefits:

- Reduces false positives for projects where semicolon-terminated identifiers are rarely direct procedure calls
- Improves call graph accuracy by focusing on unambiguous `name(...)` syntax
- Makes initial parsing stage more efficient when SEMI-terminated calls are not desired
- Maintains backward compatibility with default setting (False)

This feature addresses user requirements for more precise call detection while maintaining existing functionality.

Completes and closes #68 